### PR TITLE
fix: use iso-8859-2 encoding to parse ropts

### DIFF
--- a/custom_components/dijnet/controller.py
+++ b/custom_components/dijnet/controller.py
@@ -387,7 +387,7 @@ class DijnetController:
             search_page = await session.get_invoice_search_page()
 
             providers_json = re.search(
-                r'var ropts = (.*);', search_page.decode("windows-1252")
+                r'var ropts = (.*);', search_page.decode("iso-8859-2")
             ).groups(1)[0]
 
             raw_providers: List[Any] = json.loads(providers_json)


### PR DESCRIPTION
### Description
This PR modifies the code to read search page result as iso-8859-2 instead of windows-1252.