### PR TITLE
fix: set state to paid if paid but no payment date found

### DIFF
--- a/custom_components/dijnet/controller.py
+++ b/custom_components/dijnet/controller.py
@@ -462,8 +462,12 @@ class DijnetController:
                             invoice = self._create_invoice_from_row(row, paid_at)
                             possible_new_paid_invoices.append(invoice)
                         else:
-                            # not paid?
-                            invoice = self._create_invoice_from_row(row)
+                            # payment info not found, but invoice paid
+                            paid_at = datetime.strptime(row.children(
+                                'td:nth-child(6)').text(), DATE_FORMAT
+                            ).replace(tzinfo=None).date().isoformat()
+                            invoice = self._create_invoice_from_row(row, paid_at)
+                            possible_new_paid_invoices.append(invoice)
 
                     if invoice is None:
                         _LOGGER.warning(


### PR DESCRIPTION
### Description
This PR sets adds the invoice to paid invoice backet if state is paid but no payment date found. The payment date in that case will be the deadline.