### PR TITLE
fix: remove iot_class from hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,6 @@
     "name": "Dijnet integration",
     "country": "HU",
     "render_readme": true,
-    "iot_class": "Cloud Polling",
     "zip_release": true,
     "filename": "homeassistant-dijnet.zip"
 }


### PR DESCRIPTION
### Description
This PR removes `iot_class` from hacs.json to pass validation.